### PR TITLE
Allow scriptExtensionsTest option to be overridden in config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ class WebpackRemoveEmptyScriptsPlugin {
         },
         (assets) => {
           Object.keys(assets).forEach((filename) => {
-            if (!defaultOptions.scriptExtensionsTest.test(filename)) return;
+            if (!this.options.scriptExtensionsTest.test(filename)) return;
 
             const outputPath = compiler.options.output.path;
             const [, name] = entryNameRegExp.exec(filename);


### PR DESCRIPTION
It's an edge case really, but I need to have a .js file extracted from the bundle (which has a .js extension) and the plugin will incorrectly remove that .js file and not only the bundle. So this option will allow me to set an unusual extension for the bundle (like .rem.js) and setup the plugin to look for that instead.