### PR TITLE
fix: represent export correctly in types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,7 +9,9 @@ interface IOptions {
   verbose: boolean;
 }
 
-export type WebpackRemoveEmptyScriptsPluginOptions = Partial<IOptions>;
+declare namespace WebpackRemoveEmptyScriptsPlugin {
+  export type Options = Partial<IOptions>;
+}
 
 declare class WebpackRemoveEmptyScriptsPlugin implements WebpackPluginInstance {
   [index: string]: any;
@@ -17,9 +19,9 @@ declare class WebpackRemoveEmptyScriptsPlugin implements WebpackPluginInstance {
   public static STAGE_BEFORE_PROCESS_PLUGINS: number;
   public static STAGE_AFTER_PROCESS_PLUGINS: number;
 
-  constructor(options: WebpackRemoveEmptyScriptsPluginOptions);
+  constructor(options: WebpackRemoveEmptyScriptsPlugin.Options);
 
   apply(compiler: Compiler): void;
 }
 
-export default WebpackRemoveEmptyScriptsPlugin;
+export = WebpackRemoveEmptyScriptsPlugin;


### PR DESCRIPTION
The current types are incorrect because this plugin is exported using `module.exports` which is not equivalent to `export default`; while TypeScript handles this under the hood for native TS files (which is why those don't error), attempting to use this module with `require` in JS files checked by TypeScript will result in an error:

<img width="854" alt="image" src="https://user-images.githubusercontent.com/3151613/230511434-a27e63a0-4962-4193-8caf-cfb2582dc7c7.png">


This is because TypeScript expects such modules to be exporting a `default` property that should be used in CommonJS, so instead it wants us to do `{ default: RemoveEmptyScriptsPlugin }`:

<img width="536" alt="image" src="https://user-images.githubusercontent.com/3151613/230511467-d82252c4-d59a-4a79-9a54-0e5d5f1b939c.png">

This property does not actually exist at runtime though:

<img width="532" alt="image" src="https://user-images.githubusercontent.com/3151613/230511565-c79002c2-e6f5-4e2a-aa64-7b2c5a71f76f.png">

Instead, the correct way to type a `module.exports` based export is to use `export =`, and then to use a `namespace` to export additional types and interfaces (as there can only be one top-level export).